### PR TITLE
Avoid P inside P

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -30,10 +30,8 @@ class LambdaCall extends Component {
           >
             {loading ? "Loading..." : "Generate Lorem Ipsum"}
           </button>
-          <br />
-
-          {msg && parse(msg)}
         </p>
+        {msg && parse(msg)}
       </>
     );
   }

--- a/src/Footer.js
+++ b/src/Footer.js
@@ -11,10 +11,10 @@ export class Footer extends React.Component {
           <a href="https://github.com/M0nica/greys-anatomy-lorem-ipsum-generator">
             View Code
           </a>
-          <p>
-            Copyright to "Grey's Anatomy" is held by various outside entities
-            and is provided here for educational purposes only.
-          </p>
+        </p>
+        <p>
+          Copyright to "Grey's Anatomy" is held by various outside entities
+          and is provided here for educational purposes only.
         </p>
       </div>
     );


### PR DESCRIPTION
P inside of P, throws a warning

```
01:17:26.084 Warning: validateDOMNesting(...): <p> cannot appear as a descendant of <p>.
    in p (at Footer.js:14)
    in p (at Footer.js:7)
    in div (at Footer.js:6)
    in Footer (at App.js:53)
    in div (at App.js:45)
    in App (at src/index.js:7) index.js:1437
    e index.js:1437
    React 21
    js index.js:7
    Webpack 7
```